### PR TITLE
#6 Prevent Toggling All Unlinked Refs on Click

### DIFF
--- a/src/features/editor/Editor.js
+++ b/src/features/editor/Editor.js
@@ -52,7 +52,7 @@ const Editor = ({ blockId, isRoot, isMain, stopRecursion = false }) => {
         </div>
       }
       {isRoot &&
-        <References block={block} isMain={isMain} />
+        <References block={block} isMain={isMain} key={block.id} />
       }
     </div>
   )

--- a/src/features/editor/References.js
+++ b/src/features/editor/References.js
@@ -8,7 +8,7 @@ const References = ({ block, isMain }) => {
   const [showUnlinkedRefs, setShowUnlinkedRefs] = useState(false)
   const links = useSelector(state => state.links)
   const blocks = useSelector(state => state.blocks)
-  const references = links[block.id]
+  const references = links.to[block.id]
 
   const linkedReferences = () => {
     if (block.parentId || !references || !references.length) {


### PR DESCRIPTION
Unlinked refs were being toggled on every page after a single click on
one. This was because the <References> element in Editor.js was not
re-rendering as expected. It was sticking around and the hooks state
was shared among other pages' <References> elements. The calculation
of the unlinked references was only being done on page load, but it was
still unwelcome. Add key prop to differentiate the instances among pages.

Also fix bug where linked references were not showing because of a lapse
syncing code changes with redux.

Closes #6 