### PR TITLE
#17 Fix Block Expand/Collapse Functionality

### DIFF
--- a/src/features/block-actions/BlockActions.js
+++ b/src/features/block-actions/BlockActions.js
@@ -5,10 +5,10 @@ import './block-actions.scss'
 
 import PageLink from '../links/PageLink'
 
-const BlockActions = ({ block, foldBlock, setFoldBlock }) => {
+const BlockActions = ({ block, hasChildren, foldBlock, setFoldBlock }) => {
   return (
     <div className="block-actions-container">
-      <span className="block-actions block-actions--toggle">
+      <span className={`block-actions block-actions--toggle${hasChildren ? '' : ' hidden'}`}>
         {foldBlock &&
           <CaretRightFill color="white" onClick={() => setFoldBlock(false)} />
         }
@@ -20,7 +20,9 @@ const BlockActions = ({ block, foldBlock, setFoldBlock }) => {
         pageBlockId={block.id}
         noStyling
       >
-        <span className="block-actions block-actions--bullet">•</span>
+        <div className={`block-actions block-actions--bullet${foldBlock && hasChildren ? ' fold' : ''}`}>
+          <span>•</span>
+        </div>
       </PageLink>
     </div>
   )

--- a/src/features/block-actions/BlockActions.js
+++ b/src/features/block-actions/BlockActions.js
@@ -1,6 +1,7 @@
 import React from 'react'
-
 import { CaretRightFill, CaretDownFill } from 'react-bootstrap-icons'
+
+import './block-actions.scss'
 
 import PageLink from '../links/PageLink'
 

--- a/src/features/block-actions/block-actions.scss
+++ b/src/features/block-actions/block-actions.scss
@@ -3,7 +3,7 @@
     display: flex;
 }
 
-.block-actions {
+.block-actions:not(.hidden) {
     cursor: pointer;
 }
 
@@ -13,7 +13,26 @@
     transition: opacity 0.1s ease-in-out;
     margin-right: 3px;
 
-    .block-actions-container:hover & {
+    .block-actions-container:hover &:not(.hidden) {
         opacity: 1;
+    }
+}
+
+.block-actions--bullet {
+    position: relative;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    top: 7px;
+    left: -2px;
+
+    &.fold {
+        background-color: gray;
+    }
+
+    span {
+        position: relative;
+        top: -8px;
+        left: 2.5px;
     }
 }

--- a/src/features/block-actions/block-actions.scss
+++ b/src/features/block-actions/block-actions.scss
@@ -1,0 +1,19 @@
+.block-actions-container {
+    margin-right: 10px;
+    display: flex;
+}
+
+.block-actions {
+    cursor: pointer;
+}
+
+.block-actions--toggle {
+    opacity: 0;
+    font-size: 14px;
+    transition: opacity 0.1s ease-in-out;
+    margin-right: 3px;
+
+    .block-actions-container:hover & {
+        opacity: 1;
+    }
+}

--- a/src/features/block/Block.js
+++ b/src/features/block/Block.js
@@ -7,13 +7,12 @@ import TextareaAutosize from 'react-textarea-autosize'
 import './block.scss'
 
 import { addBlock, removeBlock, updateBlock, repositionBlock, BlockModel, makeSibling } from './blockSlice'
-import BlockActions from './BlockActions'
 import { setLinks } from '../links/linksSlice'
 import PageLink from '../links/PageLink'
 import { updateFocusedBlock } from '../editor/editorSlice'
-import Search from '../search/Search';
+import Search from '../search/Search'
 
-const Block = ({ block, isMain, isTitle, foldBlock, setFoldBlock }) => {
+const Block = ({ block, isMain, isTitle }) => {
   const dispatch = useDispatch()
   const textarea = useRef(null)
   const blocks = useSelector(state => state.blocks)
@@ -241,13 +240,6 @@ const Block = ({ block, isMain, isTitle, foldBlock, setFoldBlock }) => {
 
   return (
       <div className="block">
-      {!isTitle &&
-        <BlockActions
-          block={block}
-          foldBlock={foldBlock}
-          setFoldBlock={setFoldBlock}
-        />
-      }
       {editing
         ?
           <div className="block__autocomplete-container">

--- a/src/features/block/block.scss
+++ b/src/features/block/block.scss
@@ -4,11 +4,6 @@
     display: flex;
 }
 
-.block-actions-container {
-    margin-right: 10px;
-    display: flex;
-}
-
 .block-text {
     @extend .text-light;
     overflow: hidden;
@@ -31,21 +26,6 @@
     @extend .h1;
     @extend .d-block;
     margin-bottom: 32px;
-}
-
-.block-actions {
-    cursor: pointer;
-}
-
-.block-actions--toggle {
-    opacity: 0;
-    font-size: 14px;
-    transition: opacity 0.1s ease-in-out;
-    margin-right: 3px;
-
-    .block-actions-container:hover & {
-        opacity: 1;
-    }
 }
 
 .block__autocomplete-container {

--- a/src/features/editor/Editor.js
+++ b/src/features/editor/Editor.js
@@ -47,6 +47,7 @@ const Editor = ({ blockId, isRoot, isMain, fold = false }) => {
             block={block}
             foldBlock={foldBlock}
             setFoldBlock={setFoldBlock}
+            hasChildren={children.length > 0}
           />
         }
         <Block


### PR DESCRIPTION
- Allow blocks to be expanded both by thread line or block caret toggle independently of each other
- Style block actions to show which blocks are toggled/folded
- Don't show block caret toggles if block doesn't have children