### PR TITLE
Feature/9 caret positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14109,6 +14109,11 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
+    "textarea-caret": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/textarea-caret/-/textarea-caret-3.1.0.tgz",
+      "integrity": "sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q=="
+    },
     "throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-string-replace": "^0.4.4",
     "react-textarea-autosize": "^8.3.0",
     "redux": "^4.0.5",
+    "textarea-caret": "^3.1.0",
     "uuid": "^8.3.2",
     "web-vitals": "^0.2.4"
   },

--- a/src/App.scss
+++ b/src/App.scss
@@ -2,3 +2,8 @@
   display: flex;
   min-height: 100vh;
 }
+
+.pane {
+  max-height: 100vh;
+  overflow: auto;
+}

--- a/src/features/block/Block.js
+++ b/src/features/block/Block.js
@@ -236,9 +236,7 @@ const Block = ({ block, isMain, isTitle }) => {
         skippedSymbolIndexes.push(caretPos)
         caretPos--
       }
-      const coordinates = getCaretCoordinates(_textarea, caretPos)
-      const x = coordinates.left
-      const y = coordinates.top
+      const { left: x, top: y } = getCaretCoordinates(_textarea, caretPos)
       const distance = Math.sqrt(Math.pow((x - cursorCaret.offsetX), 2) + Math.pow((y - cursorCaret.offsetY), 2))
       if (distance < minDistance) {
         minDistance = distance

--- a/src/features/block/Block.js
+++ b/src/features/block/Block.js
@@ -3,6 +3,7 @@ import { compiler } from 'markdown-to-jsx'
 import reactStringReplace from "react-string-replace";
 import { useDispatch, useSelector } from 'react-redux'
 import TextareaAutosize from 'react-textarea-autosize'
+import getCaretCoordinates from 'textarea-caret'
 
 import './block.scss'
 
@@ -21,6 +22,7 @@ const Block = ({ block, isMain, isTitle }) => {
   const [editing, setEditing] = useState(focusedBlock.isMain === isMain && focusedBlock.blockId === block.id)
   const [searching, setSearching] = useState(false)
   const [query, setQuery] = useState(false)
+  const [cursorCaret, setCursorCaret] = useState({ offsetX: null, offsetY: null, width: null })
 
   const linkToPage = text => {
     const foundPage = Object.values(blocks)
@@ -202,6 +204,59 @@ const Block = ({ block, isMain, isTitle }) => {
     dispatch(updateBlock({ blockId: block.id, text: newValue }))
   }
 
+  const edit = event => {
+    const clickPosX = event.clientX
+    const clickPosY = event.clientY
+    const blockX = event.currentTarget.offsetLeft
+    const blockY = event.currentTarget.offsetTop
+    const offsetX = clickPosX - blockX
+    const offsetY = clickPosY - blockY
+    const width = event.currentTarget.offsetWidth
+    setCursorCaret({ offsetX, offsetY, width })
+    setEditing(true)
+  }
+
+  const translateCaretPos = (_textarea) => {
+    if (!_textarea) {
+      return
+    }
+
+    const symbolsToSkip = ['*', '_']
+    const originalText = _textarea.value
+
+    let minDistance = 10000
+    let translatedCaretPos = 0
+    let skippedSymbolIndexes = []
+    for (let caretPos = 0; caretPos <= _textarea.value.length; caretPos++) {
+      const currentChar = _textarea.value.charAt(caretPos)
+      if (symbolsToSkip.includes(currentChar)) {
+        const chars = _textarea.value.split('')
+        chars.splice(caretPos, 1)
+        _textarea.value = chars.join('')
+        skippedSymbolIndexes.push(caretPos)
+        caretPos--
+      }
+      const coordinates = getCaretCoordinates(_textarea, caretPos)
+      const x = coordinates.left
+      const y = coordinates.top
+      const distance = Math.sqrt(Math.pow((x - cursorCaret.offsetX), 2) + Math.pow((y - cursorCaret.offsetY), 2))
+      if (distance < minDistance) {
+        minDistance = distance
+        translatedCaretPos = caretPos
+      }
+    }
+
+    _textarea.value = originalText
+    let newCaretPos = translatedCaretPos
+    if (skippedSymbolIndexes.length && skippedSymbolIndexes[0] <= newCaretPos) {
+      newCaretPos += skippedSymbolIndexes.filter(index => index <= translatedCaretPos).length
+    }
+    _textarea.selectionStart = newCaretPos
+    _textarea.selectionEnd = newCaretPos
+
+    setCursorCaret({ offsetX: null, offsetY: null, width: null })
+  }
+
   const save = event => {
     if (!searching && block.text !== event.target.value) {
       dispatch(updateBlock({ blockId: block.id, text: event.target.value }))
@@ -216,6 +271,8 @@ const Block = ({ block, isMain, isTitle }) => {
   const setCaretPos = event => {
     if (isFocusedBlock) {
       event.target.selectionStart = focusedBlock.caretPos
+    } else if (cursorCaret.offsetX !== null) {
+      translateCaretPos(event.target)
     }
   }
 
@@ -265,7 +322,7 @@ const Block = ({ block, isMain, isTitle }) => {
         :
         <span
           className={className}
-          onClick={() => setEditing(true)}
+          onClick={edit}
         >
           {rendered()}
         </span>

--- a/src/features/block/block.scss
+++ b/src/features/block/block.scss
@@ -2,6 +2,7 @@
 
 .block {
     display: flex;
+    width: 100%;
 }
 
 .block-text {
@@ -20,6 +21,7 @@
     border-style: none;
     outline: none;
     padding: 0;
+    margin-bottom: -2px;
 }
 
 .block-text--title {

--- a/src/features/file-pane/FilePane.js
+++ b/src/features/file-pane/FilePane.js
@@ -67,7 +67,7 @@ const FilePane = props => {
   })
 
   return (
-    <div className="file-pane">
+    <div className="pane file-pane">
       <Link to="/"><h2 className="text-light text-center">Free-roam</h2></Link>
       <div className="d-flex justify-content-center">
         <label className="load-button-input mr-3">

--- a/src/features/view-pane/ViewPane.js
+++ b/src/features/view-pane/ViewPane.js
@@ -35,7 +35,7 @@ const ViewPane = props => {
     )
   })
   return (
-    <div className="view-pane">
+    <div className="pane view-pane">
       {viewPaneBlocks}
     </div>
   )

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,6 +9,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   @extend .text-light;
   @extend .bg-dark;
+  overflow: hidden;
 }
 
 code {


### PR DESCRIPTION
When clicking on a block to edit, the caret will now go right where your cursor was. This also takes into account markdown symbols (asterisk and underscore, for now).

Closes #9