### PR TITLE
#21 Allow Arrow Up/Down Through Blocks

### DIFF
--- a/src/features/block/Block.js
+++ b/src/features/block/Block.js
@@ -34,7 +34,7 @@ const Block = ({ block, isMain, isTitle }) => {
   const isFocusedBlock = focusedBlock.blockId
     && focusedBlock.blockId === block.id
     && focusedBlock.isMain === isMain
-    && focusedBlock.caretPos
+    && !isNaN(focusedBlock.caretPos)
 
   if (isFocusedBlock && !editing) {
     setEditing(true)

--- a/src/features/block/blockModel.js
+++ b/src/features/block/blockModel.js
@@ -54,7 +54,15 @@ export const getPage = (block, blocks) => {
   return getPage(parentBlock, blocks)
 }
 
+export const isFirstPageChild = (block, blocks) => {
+  const pageBlock = getPage(block, blocks)
+  return block.parentId === pageBlock.id && pageBlock.childrenIds[0] === block.id
+}
+
 export const getPrevSibling = (block, blocks) => {
+  if (block.parentId === null) {
+    return null
+  }
   const parentBlock = blocks[block.parentId]
   const blockIndex = parentBlock.childrenIds.indexOf(block.id)
   if (blockIndex < 1) {
@@ -62,6 +70,19 @@ export const getPrevSibling = (block, blocks) => {
   }
   const prevSiblingBlock = blocks[parentBlock.childrenIds[blockIndex - 1]]
   return prevSiblingBlock
+}
+
+export const getNextSibling = (block, blocks) => {
+  if (block.parentId === null) {
+    return null
+  }
+  const parentBlock = blocks[block.parentId]
+  const blockIndex = parentBlock.childrenIds.indexOf(block.id)
+  if (blockIndex === parentBlock.childrenIds.length - 1) {
+    return null
+  }
+  const nextSiblingBlock = blocks[parentBlock.childrenIds[blockIndex + 1]]
+  return nextSiblingBlock
 }
 
 export const getLastChildLeaf = (block, blocks) => {
@@ -73,6 +94,9 @@ export const getLastChildLeaf = (block, blocks) => {
 }
 
 export const getNextBlockUp = (block, blocks) => {
+  if (!block.parentId || isFirstPageChild(block, blocks)) {
+    return null
+  }
   const prevSibling = getPrevSibling(block, blocks)
   if (prevSibling) {
     if (prevSibling.childrenIds.length) {
@@ -84,6 +108,20 @@ export const getNextBlockUp = (block, blocks) => {
     const parentBlock = blocks[block.parentId]
     return parentBlock
   }
+}
+
+export const getNextBlockDown = (block, blocks, checkChildren=true) => {
+  if (block.parentId === null) {
+    return null
+  }
+  if (checkChildren && block.childrenIds.length) {
+    return blocks[block.childrenIds[0]]
+  }
+  const nextSibling = getNextSibling(block, blocks)
+  if (nextSibling) {
+    return nextSibling
+  }
+  return getNextBlockDown(blocks[block.parentId], blocks, checkChildren=false)
 }
 
 export const serialize = (block, blocks) => {

--- a/src/features/block/blockModel.spec.js
+++ b/src/features/block/blockModel.spec.js
@@ -1,0 +1,180 @@
+import * as blockModel from './blockModel'
+
+describe('blockModel', () => {
+  describe('getPage', () => {
+    test('should return a block\'s page, no matter the block\'s depth', () => {
+      const blocks = {
+        a: { id: 'a', parentId: null, text: 'I\'m the page block', childrenIds: ['b'] },
+        b: { id: 'b', parentId: 'a', text: 'I\'m a block', childrenIds: ['c'] },
+        c: { id: 'c', parentId: 'b', text: 'I\'m a child block' }
+      }
+
+      let block = blocks.b
+      let expectedPageBlockId = 'a'
+      let actualPageBlockId = blockModel.getPage(block, blocks).id
+      expect(expectedPageBlockId).toEqual(actualPageBlockId)
+
+      block = blocks.c
+      expectedPageBlockId = 'a'
+      actualPageBlockId = blockModel.getPage(block, blocks).id
+      expect(expectedPageBlockId).toEqual(actualPageBlockId)
+    })
+  })
+
+  describe('isFirstPageChild', () => {
+    test('should return true when the given block is a page\'s first child block', () => {
+      const blocks = {
+        a: { id: 'a', parentId: null, text: 'I\'m the page block', childrenIds: ['b'] },
+        b: { id: 'b', parentId: 'a', text: 'I\'m the page\'s first child block', childrenIds: ['c'] },
+        c: { id: 'c', parentId: 'b', text: 'I\'m a child block' },
+        d: { id: 'd', parentId: 'a', text: 'I\'m another block' }
+      }
+
+      let block = blocks.b
+      let result = blockModel.isFirstPageChild(block, blocks)
+      expect(result).toBe(true)
+
+      block = blocks.c
+      result = blockModel.isFirstPageChild(block, blocks)
+      expect(result).toBe(false)
+
+      block = blocks.d
+      result = blockModel.isFirstPageChild(block, blocks)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getPreviousSibling', () => {
+    test('should return a block\'s previous sibling block if one exists, otherwise null', () => {
+      const blocks = {
+        a: { id: 'a', parentId: null, text: 'I\'m the page block', childrenIds: ['b', 'd'] },
+        b: { id: 'b', parentId: 'a', text: 'I\'m a block', childrenIds: ['c'] },
+        c: { id: 'c', parentId: 'b', text: 'I\'m a child block', childrenIds: [] },
+        d: { id: 'd', parentId: 'a', text: 'I\'m another block', childrenIds: [] }
+      }
+
+      let block = blocks.a
+      let prevSibling = blockModel.getPrevSibling(block, blocks)
+      expect(prevSibling).toBeNull()
+
+      block = blocks.b
+      prevSibling = blockModel.getPrevSibling(block, blocks)
+      expect(prevSibling).toBeNull()
+
+      block = blocks.c
+      prevSibling = blockModel.getPrevSibling(block, blocks)
+      expect(prevSibling).toBeNull()
+
+      block = blocks.d
+      prevSibling = blockModel.getPrevSibling(block, blocks)
+      expect(prevSibling).toEqual(blocks.b)
+    })
+  })
+
+  describe('getNextSibling', () => {
+    test('should return a block\'s next sibling block if one exists, otherwise null', () => {
+      const blocks = {
+        a: { id: 'a', parentId: null, text: 'I\'m the page block', childrenIds: ['b', 'd'] },
+        b: { id: 'b', parentId: 'a', text: 'I\'m a block', childrenIds: ['c'] },
+        c: { id: 'c', parentId: 'b', text: 'I\'m a child block', childrenIds: [] },
+        d: { id: 'd', parentId: 'a', text: 'I\'m another block', childrenIds: [] }
+      }
+
+      let block = blocks.a
+      let prevSibling = blockModel.getNextSibling(block, blocks)
+      expect(prevSibling).toBeNull()
+
+      block = blocks.b
+      prevSibling = blockModel.getNextSibling(block, blocks)
+      expect(prevSibling).toEqual(blocks.d)
+
+      block = blocks.c
+      prevSibling = blockModel.getNextSibling(block, blocks)
+      expect(prevSibling).toBeNull()
+
+      block = blocks.d
+      prevSibling = blockModel.getNextSibling(block, blocks)
+      expect(prevSibling).toBeNull()
+    })
+  })
+
+  describe('getLastChildLeaf', () => {
+    test('should return a block\'s last child block, recursively', () => {
+      const blocks = {
+        a: { id: 'a', parentId: null, text: 'I\'m the page block', childrenIds: ['b'] },
+        b: { id: 'b', parentId: 'a', text: 'I\'m the first regular block', childrenIds: ['c', 'd'] },
+        c: { id: 'c', parentId: 'b', text: 'I\'m a grandchild block', childrenIds: [] },
+        d: { id: 'd', parentId: 'b', text: 'I\'m another grandchild block', childrenIds: [] }
+      }
+
+      let block = blocks.a
+      let lastChildLeaf = blockModel.getLastChildLeaf(block, blocks)
+      expect(lastChildLeaf).toEqual(blocks.d)
+
+      block = blocks.b
+      lastChildLeaf = blockModel.getLastChildLeaf(block, blocks)
+      expect(lastChildLeaf).toEqual(blocks.d)
+
+      block = blocks.c
+      lastChildLeaf = blockModel.getLastChildLeaf(block, blocks)
+      expect(lastChildLeaf).toEqual(blocks.c)
+    })
+  })
+
+  describe('getNextBlockUp', () => {
+    const blocks = {
+      a: { id: 'a', parentId: null, text: 'I\'m the page block', childrenIds: ['b'] },
+      b: { id: 'b', parentId: 'a', text: 'I\'m a block', childrenIds: ['c', 'd'] },
+      c: { id: 'c', parentId: 'b', text: 'I\'m a child block', childrenIds: [] },
+      d: { id: 'd', parentId: 'b', text: 'I\'m another child block', childrenIds: [] }
+    }
+    test('should return the block visibly above the current if one exists, otherwise null', () => {
+      let block = blocks.c
+      let nextBlockUp = blockModel.getNextBlockUp(block, blocks)
+      expect(nextBlockUp).toEqual(blocks.b)
+
+      block = blocks.d
+      nextBlockUp = blockModel.getNextBlockUp(block, blocks)
+      expect(nextBlockUp).toEqual(blocks.c)
+    })
+
+    test('should return null if the current block is the first one on the page', () => {
+      let block = blocks.b
+      let nextBlockUp = blockModel.getNextBlockUp(block, blocks)
+      expect(nextBlockUp).toBeNull()
+    })
+
+    test('should return null if the current block is the page block', () => {
+      let block = blocks.a
+      let nextBlockUp = blockModel.getNextBlockUp(block, blocks)
+      expect(nextBlockUp).toBeNull()
+    })
+  })
+
+  describe('getNextBlockDown', () => {
+    const blocks = {
+      a: { id: 'a', parentId: null, text: 'I\'m the page block', childrenIds: ['b'] },
+      b: { id: 'b', parentId: 'a', text: 'I\'m the a block', childrenIds: ['c', 'd'] },
+      c: { id: 'c', parentId: 'b', text: 'I\'m a child block', childrenIds: [] },
+      d: { id: 'd', parentId: 'b', text: 'I\'m another child block', childrenIds: [] }
+    }
+    test('should return the block visibly below the current if one exists, otherwise null', () => {
+      let block = blocks.b
+      let nextBlockDown = blockModel.getNextBlockDown(block, blocks)
+      expect(nextBlockDown).toEqual(blocks.c)
+
+      block = blocks.c
+      nextBlockDown = blockModel.getNextBlockDown(block, blocks)
+      expect(nextBlockDown).toEqual(blocks.d)
+
+      block = blocks.d
+      nextBlockDown = blockModel.getNextBlockDown(block, blocks)
+      expect(nextBlockDown).toBeNull()
+    })
+    test('should return null if the current block is the page block', () => {
+      let block = blocks.a
+      let nextBlockDown = blockModel.getNextBlockDown(block, blocks)
+      expect(nextBlockDown).toBeNull()
+    })
+  })
+})

--- a/src/features/block/editUtils.js
+++ b/src/features/block/editUtils.js
@@ -1,3 +1,5 @@
+import getCaretCoordinates from 'textarea-caret'
+
 export const getCaretInfo = (text, caretPos) => {
   const wikiLinkRegex = /\[\[([^\]]*(?:\]\])?)\]\]/gm
   const matches = text.matchAll(wikiLinkRegex)
@@ -18,4 +20,14 @@ export const getCaretInfo = (text, caretPos) => {
     }
   }
   return { startBracketIndex, endBracketIndex, caretInBrackets, textInBrackets }
+}
+
+export const isCaretOnFirstRow = (textarea, lineHeight) => {
+  const { top } = getCaretCoordinates(textarea, textarea.selectionStart)
+  return top <= lineHeight
+}
+
+export const isCaretOnLastRow = (textarea, lineHeight) => {
+  const { top } = getCaretCoordinates(textarea, textarea.selectionStart)
+  return textarea.offsetHeight <= top + lineHeight
 }

--- a/src/features/block/editUtils.spec.js
+++ b/src/features/block/editUtils.spec.js
@@ -1,75 +1,77 @@
 import { getCaretInfo } from './editUtils'
 
 describe('editUtils', () => {
-  const testCases = [
-    {
-      text: 'ab|c',
-      caretPos: 2,
-      caretInfo: {
-        startBracketIndex: -1,
-        endBracketIndex: -1,
-        caretInBrackets: false,
-        textInBrackets: null
+  describe('getCaretInfo', () => {
+    const testCases = [
+      {
+        text: 'ab|c',
+        caretPos: 2,
+        caretInfo: {
+          startBracketIndex: -1,
+          endBracketIndex: -1,
+          caretInBrackets: false,
+          textInBrackets: null
+        }
+      }, {
+        text: '[[ab|c',
+        caretPos: 4,
+        caretInfo: {
+          startBracketIndex: -1,
+          endBracketIndex: -1,
+          caretInBrackets: false,
+          textInBrackets: null
+        }
+      }, {
+        text: '[[a]] b|c',
+        caretPos: 7,
+        caretInfo: {
+          startBracketIndex: -1,
+          endBracketIndex: -1,
+          caretInBrackets: false,
+          textInBrackets: null
+        }
+      }, {
+        text: '[[[[a]] b|c',
+        caretPos: 9,
+        caretInfo: {
+          startBracketIndex: -1,
+          endBracketIndex: -1,
+          caretInBrackets: false,
+          textInBrackets: null
+        }
+      }, {
+        text: '[[ab|c]]',
+        caretPos: 4,
+        caretInfo: {
+          startBracketIndex: 0,
+          endBracketIndex: 6,
+          caretInBrackets: true,
+          textInBrackets: 'ab|c'
+        }
+      }, {
+        text: '[[[[ab|c]]',
+        caretPos: 6,
+        caretInfo: {
+          startBracketIndex: 0,
+          endBracketIndex: 8,
+          caretInBrackets: true,
+          textInBrackets: '[[ab|c'
+        }
+      }, {
+        text: '[[[[ab|c]]]]',
+        caretPos: 6,
+        caretInfo: {
+          startBracketIndex: 0,
+          endBracketIndex: 10,
+          caretInBrackets: true,
+          textInBrackets: '[[ab|c]]'
+        }
       }
-    }, {
-      text: '[[ab|c',
-      caretPos: 4,
-      caretInfo: {
-        startBracketIndex: -1,
-        endBracketIndex: -1,
-        caretInBrackets: false,
-        textInBrackets: null
-      }
-    }, {
-      text: '[[a]] b|c',
-      caretPos: 7,
-      caretInfo: {
-        startBracketIndex: -1,
-        endBracketIndex: -1,
-        caretInBrackets: false,
-        textInBrackets: null
-      }
-    }, {
-      text: '[[[[a]] b|c',
-      caretPos: 9,
-      caretInfo: {
-        startBracketIndex: -1,
-        endBracketIndex: -1,
-        caretInBrackets: false,
-        textInBrackets: null
-      }
-    }, {
-      text: '[[ab|c]]',
-      caretPos: 4,
-      caretInfo: {
-        startBracketIndex: 0,
-        endBracketIndex: 6,
-        caretInBrackets: true,
-        textInBrackets: 'ab|c'
-      }
-    }, {
-      text: '[[[[ab|c]]',
-      caretPos: 6,
-      caretInfo: {
-        startBracketIndex: 0,
-        endBracketIndex: 8,
-        caretInBrackets: true,
-        textInBrackets: '[[ab|c'
-      }
-    }, {
-      text: '[[[[ab|c]]]]',
-      caretPos: 6,
-      caretInfo: {
-        startBracketIndex: 0,
-        endBracketIndex: 10,
-        caretInBrackets: true,
-        textInBrackets: '[[ab|c]]'
-      }
-    }
 
-  ]
+    ]
 
-  test.each(testCases)('getCaretInfo(%o)', testCase => {
-    expect(getCaretInfo(testCase.text, testCase.caretPos)).toEqual(testCase.caretInfo)
+    test.each(testCases)('getCaretInfo(%o)', testCase => {
+      expect(getCaretInfo(testCase.text, testCase.caretPos)).toEqual(testCase.caretInfo)
+    })
   })
 })


### PR DESCRIPTION
Allow users to use the arrow up/down keys to navigate between
blocks. This respects hard newlines made using Shift+Enter.

### P.S.

- Fix focusedBlock bug where a caretPos of 0 was being interpreted
as false in a boolean expression
- Don't set selectionStart automatically within `<EditBlock />`, when
it gets set via arrow up/down and then the user enters text, the
caret goes back to focusedBlock.caretPos and starts typing in the
middle of words.
- The arrow/up down isn't high fidelity; the column does not stay the
same through the block indents, but it's good enough for now.