### PR TITLE
#14 Collapsible Sidebars

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { HashRouter as Router } from 'react-router-dom';
+import { List } from 'react-bootstrap-icons'
 
 import './App.scss'
 
@@ -7,14 +8,29 @@ import Main from './features/main/Main'
 import FilePane from './features/file-pane/FilePane'
 import ViewPane from './features/view-pane/ViewPane'
 
-const App = () => (
-  <div className="App">
-    <Router>
-      <FilePane />
-      <Main />
-      <ViewPane />
-    </Router>
-  </div>
-)
+const App = () => {
+  const [showFilePane, setShowFilePane] = useState(true)
+  const [showViewPane, setShowViewPane] = useState(true)
+
+  return (
+    <div className="App">
+      <Router>
+        {showFilePane
+          ? <FilePane setShowFilePane={setShowFilePane} />
+          : <div className="show-sidebar__button" onClick={() => setShowFilePane(true)}>
+              <List size={20} />
+            </div>
+        }
+        <Main />
+        {showViewPane
+          ? <ViewPane setShowViewPane={setShowViewPane} />
+          : <div className="show-sidebar__button" onClick={() => setShowViewPane(true)}>
+              <List size={20} />
+            </div>
+        }
+      </Router>
+    </div>
+  )
+}
 
 export default App

--- a/src/features/editor/References.js
+++ b/src/features/editor/References.js
@@ -93,8 +93,8 @@ const References = ({ block, isMain }) => {
         <div className="references references--linked">
           <span className="references__toggle no-select" onClick={() => setShowLinkedRefs(state => !state)}>
             {showLinkedRefs
-             ? <CaretDownFill color="white" />
-             : <CaretRightFill color="white" />
+              ? <CaretDownFill color="white" size={12} />
+              : <CaretRightFill color="white" size={12} />
             }
             <b>{references.length} Linked References</b>
           </span>
@@ -107,8 +107,8 @@ const References = ({ block, isMain }) => {
         <div className="references references--unlinked">
           <span className="references__toggle no-select" onClick={toggleUnlinkedReferences}>
             {showUnlinkedRefs
-             ? <CaretDownFill color="white" />
-             : <CaretRightFill color="white" />
+              ? <CaretDownFill color="white" size={12} />
+              : <CaretRightFill color="white" size={12} />
             }
             <b>{unlinkedRefs && unlinkedRefs.length ? unlinkedRefs.length : ''} Unlinked References</b>
           </span>

--- a/src/features/file-pane/FilePane.js
+++ b/src/features/file-pane/FilePane.js
@@ -1,15 +1,18 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import { Calendar3, Justify } from 'react-bootstrap-icons'
+import { Calendar3, Justify, List, CaretLeftFill } from 'react-bootstrap-icons'
 
 import './file-pane.scss'
 
 import Shortcuts from './Shortcuts'
 import IO from '../io/io'
 
-const FilePane = props => {
+const FilePane = ({ setShowFilePane }) => {
   return (
     <div className="pane file-pane">
+      <div className="hide-sidebar" onClick={() => setShowFilePane(false)}>
+        <div className="hide-sidebar__button"><CaretLeftFill size={10} style={{marginRight: "-3px"}} /><List size={20}/></div>
+      </div>
       <Link to="/"><h2 className="text-light text-center">Free-roam</h2></Link>
       <IO />
       <div className="list-group list-group-flush mt-3">

--- a/src/features/file-pane/file-pane.scss
+++ b/src/features/file-pane/file-pane.scss
@@ -1,5 +1,5 @@
 .file-pane {
     min-width: 300px;
     background-color: rgba(0,0,0,0.5);
-    padding: 20px;
+    padding: 5px 20px 20px;
 }

--- a/src/features/main/main.scss
+++ b/src/features/main/main.scss
@@ -5,9 +5,27 @@
 .stage {
     > .editor, .daily-notes {
         padding: 50px 150px 120px;
+        max-width: 1000px;
+        margin: 0 auto;
     }
 
     > .all-pages {
         padding: 50px 50px 120px;
     }
+}
+
+.show-sidebar__button {
+    padding: 5px 10px;
+    height: min-content;
+}
+
+.hide-sidebar {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.show-sidebar__button, .hide-sidebar__button {
+    cursor: pointer;
+    margin-top: 8px;
 }

--- a/src/features/view-pane/ViewPane.js
+++ b/src/features/view-pane/ViewPane.js
@@ -1,80 +1,23 @@
 import React from 'react'
-import { useSelector, useDispatch } from 'react-redux'
-import { X } from "react-bootstrap-icons";
+import { useSelector } from 'react-redux'
+import { CaretRightFill, List } from "react-bootstrap-icons";
 
 import './view-pane.scss'
 
-import { pushView, popView } from './viewPaneSlice'
-import Editor from '../editor/Editor'
-import PageLink from '../links/PageLink';
-import References from '../editor/References';
+import ViewPaneBlock from './ViewPaneBlock'
 
-const ViewPane = props => {
-  const blocks = useSelector(state => state.blocks)
-  const links = useSelector(state => state.links)
+const ViewPane = ({ setShowViewPane }) => {
   const views = useSelector(state => state.viewPane.views)
-  const dispatch = useDispatch()
+  const viewPaneBlocks = views.map(view => <ViewPaneBlock view={view} />)
 
-  const closeBlock = (type, blockId, event) => {
-    dispatch(popView({ type, blockId }))
-  }
-
-  const header = (type, block) => {
-    let output
-    switch (type) {
-      case 'page':
-        output = 'Outline of:'
-        break
-      case 'block':
-        output = 'Block outline of:'
-        break
-      case 'references':
-        output = <span>References to: <PageLink blockId={block.id}>{block.text}</PageLink></span>
-        break
-      default:
-        output = 'Outline of:'
-        break
-    }
-    return output
-  }
-
-  const viewPaneBlocks = views.map(view => {
-    const { type, blockId } = view
-    if (!(blockId in blocks)) {
-      return null
-    }
-    const block = blocks[blockId]
-    const references = links.to[block.id] || []
-    return (
-      <div
-        key={`${type}-${block.id}`}
-        className="view-pane__section"
-      >
-        <div className="d-flex align-items-center">
-          {header(type, block)}
-          <div className="flex-grow-1" />
-          {type === 'page' &&
-            <button
-              className="btn btn-dark btn-sm px-1 py-0"
-              onClick={() => dispatch(pushView({ type: 'references', blockId }))}
-            >
-              {references.length}
-            </button>
-          }
-          <X
-            className="btn-close"
-            onClick={closeBlock.bind(null, type, block.id)}
-          />
-        </div>
-        {type === 'references'
-         ? <References block={block} isMain />
-         : <Editor blockId={block.id} isRoot isMain={false} />
-        }
-      </div>
-    )
-  })
   return (
     <div className="pane view-pane">
+      <div className="hide-sidebar" onClick={() => setShowViewPane(false)}>
+        <div className="hide-sidebar__button">
+          <List size={20}/>
+          <CaretRightFill size={10} style={{marginLeft: "-3px"}} />
+        </div>
+      </div>
       {viewPaneBlocks}
     </div>
   )

--- a/src/features/view-pane/ViewPaneBlock.js
+++ b/src/features/view-pane/ViewPaneBlock.js
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { X, CaretRightFill, CaretDownFill } from 'react-bootstrap-icons'
+
+import { pushView, popView } from './viewPaneSlice'
+import Editor from '../editor/Editor'
+import PageLink from '../links/PageLink'
+import References from '../editor/References'
+
+const ViewPaneBlock = ({ view }) => {
+  const [showBlock, setShowBlock] = useState(true)
+  const blocks = useSelector(state => state.blocks)
+  const links = useSelector(state => state.links)
+  const dispatch = useDispatch()
+
+  const closeBlock = (type, blockId, event) => {
+    dispatch(popView({ type, blockId }))
+  }
+
+  const header = (type, block, show) => {
+    let output
+    switch (type) {
+      case 'page':
+        output = <span>Outline of {show ? ':' : <b><PageLink blockId={block.id}>{block.text}</PageLink></b>}</span>
+        break
+      case 'block':
+        output = <span>Block outline of {show ? ':' : <b><PageLink blockId={block.id}>{block.text}</PageLink></b>}</span>
+        break
+      case 'references':
+        output = <span>References to: <PageLink blockId={block.id}>{block.text}</PageLink></span>
+        break
+      default:
+        output = <span>Outline of</span>
+        break
+    }
+    return output
+  }
+
+  const { type, blockId } = view
+  if (!(blockId in blocks)) {
+    return null
+  }
+  const block = blocks[blockId]
+  const references = links.to[block.id] || []
+  return (
+    <div
+      key={`${type}-${block.id}`}
+      className="view-pane__section"
+    >
+      <div className="d-flex align-items-center">
+        <span className="references__toggle no-select" onClick={() => setShowBlock(state => !state)}>
+          {showBlock
+            ? <CaretDownFill color="white" size={12} />
+            : <CaretRightFill color="white" size={12} />
+          }
+          {header(type, block, showBlock)}
+        </span>
+        <div className="flex-grow-1" />
+        {type === 'page' &&
+          <button
+            className="btn btn-dark btn-sm px-1 py-0"
+            onClick={() => dispatch(pushView({ type: 'references', blockId }))}
+          >
+            {references.length}
+          </button>
+        }
+        <X
+          className="btn-close"
+          onClick={closeBlock.bind(null, type, block.id)}
+        />
+      </div>
+      {showBlock
+        ? type === 'references'
+          ? <References block={block} isMain />
+          : <Editor blockId={block.id} isRoot isMain={false} />
+        : null
+      }
+    </div>
+  )
+}
+
+export default ViewPaneBlock

--- a/src/features/view-pane/view-pane.scss
+++ b/src/features/view-pane/view-pane.scss
@@ -2,10 +2,11 @@
     min-width: 300px;
     width: 300px;
     background-color: rgba(0,0,0,0.5);
+    padding: 5px 20px 20px;
 }
 
 .view-pane__section {
-    padding: 20px;
+    padding: 20px 0;
 
     &:not(:last-child) {
         border-bottom: 1px solid gray;


### PR DESCRIPTION
Added the ability to collapse/expand both sidebars

![image](https://user-images.githubusercontent.com/8757148/110254666-0b68c100-7f5e-11eb-8fed-961814277d7a.png)

![image](https://user-images.githubusercontent.com/8757148/110254674-158abf80-7f5e-11eb-8c0b-dc178c8e0aab.png)


Also, view pane blocks can now be folded/expanded

Before:

![image](https://user-images.githubusercontent.com/8757148/110254633-f12ee300-7f5d-11eb-92a8-8923cc21e5d0.png)

After:

![image](https://user-images.githubusercontent.com/8757148/110254639-f8ee8780-7f5d-11eb-8b30-d7a4a775f48e.png)
